### PR TITLE
Fix analytics admin permissions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,26 +2,6 @@ GIT
   remote: https://github.com/decidim/decidim
   revision: 91547b859a37e80bc5335b1d5684647030cb2ece
   specs:
-    decidim (0.23.1)
-      decidim-accountability (= 0.23.1)
-      decidim-admin (= 0.23.1)
-      decidim-api (= 0.23.1)
-      decidim-assemblies (= 0.23.1)
-      decidim-blogs (= 0.23.1)
-      decidim-budgets (= 0.23.1)
-      decidim-comments (= 0.23.1)
-      decidim-core (= 0.23.1)
-      decidim-debates (= 0.23.1)
-      decidim-forms (= 0.23.1)
-      decidim-generators (= 0.23.1)
-      decidim-meetings (= 0.23.1)
-      decidim-pages (= 0.23.1)
-      decidim-participatory_processes (= 0.23.1)
-      decidim-proposals (= 0.23.1)
-      decidim-sortitions (= 0.23.1)
-      decidim-surveys (= 0.23.1)
-      decidim-system (= 0.23.1)
-      decidim-verifications (= 0.23.1)
     decidim-accountability (0.23.1)
       decidim-comments (= 0.23.1)
       decidim-core (= 0.23.1)
@@ -203,7 +183,7 @@ PATH
   remote: .
   specs:
     decidim-analytics (0.23.1)
-      decidim-core (~> 0.23.1)
+      decidim-core (>= 0.20.0)
 
 GEM
   remote: https://rubygems.org/
@@ -332,6 +312,26 @@ GEM
     db-query-matchers (0.9.0)
       activesupport (>= 4.0, <= 6.0)
       rspec (~> 3.0)
+    decidim (0.23.1)
+      decidim-accountability (= 0.23.1)
+      decidim-admin (= 0.23.1)
+      decidim-api (= 0.23.1)
+      decidim-assemblies (= 0.23.1)
+      decidim-blogs (= 0.23.1)
+      decidim-budgets (= 0.23.1)
+      decidim-comments (= 0.23.1)
+      decidim-core (= 0.23.1)
+      decidim-debates (= 0.23.1)
+      decidim-forms (= 0.23.1)
+      decidim-generators (= 0.23.1)
+      decidim-meetings (= 0.23.1)
+      decidim-pages (= 0.23.1)
+      decidim-participatory_processes (= 0.23.1)
+      decidim-proposals (= 0.23.1)
+      decidim-sortitions (= 0.23.1)
+      decidim-surveys (= 0.23.1)
+      decidim-system (= 0.23.1)
+      decidim-verifications (= 0.23.1)
     declarative-builder (0.1.0)
       declarative-option (< 0.2.0)
     declarative-option (0.1.0)
@@ -488,7 +488,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
@@ -775,7 +777,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (~> 1.4)
   byebug (~> 11.0)
-  decidim (~> 0.23.1)
+  decidim (>= 0.20.0)
   decidim-analytics!
   decidim-dev!
   faker (~> 1.9)
@@ -791,4 +793,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   2.2.2
+   2.2.24

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,26 @@ GIT
   remote: https://github.com/decidim/decidim
   revision: 91547b859a37e80bc5335b1d5684647030cb2ece
   specs:
+    decidim (0.23.1)
+      decidim-accountability (= 0.23.1)
+      decidim-admin (= 0.23.1)
+      decidim-api (= 0.23.1)
+      decidim-assemblies (= 0.23.1)
+      decidim-blogs (= 0.23.1)
+      decidim-budgets (= 0.23.1)
+      decidim-comments (= 0.23.1)
+      decidim-core (= 0.23.1)
+      decidim-debates (= 0.23.1)
+      decidim-forms (= 0.23.1)
+      decidim-generators (= 0.23.1)
+      decidim-meetings (= 0.23.1)
+      decidim-pages (= 0.23.1)
+      decidim-participatory_processes (= 0.23.1)
+      decidim-proposals (= 0.23.1)
+      decidim-sortitions (= 0.23.1)
+      decidim-surveys (= 0.23.1)
+      decidim-system (= 0.23.1)
+      decidim-verifications (= 0.23.1)
     decidim-accountability (0.23.1)
       decidim-comments (= 0.23.1)
       decidim-core (= 0.23.1)
@@ -183,7 +203,7 @@ PATH
   remote: .
   specs:
     decidim-analytics (0.23.1)
-      decidim-core (>= 0.20.0)
+      decidim-core (~> 0.23.1)
 
 GEM
   remote: https://rubygems.org/
@@ -312,26 +332,6 @@ GEM
     db-query-matchers (0.9.0)
       activesupport (>= 4.0, <= 6.0)
       rspec (~> 3.0)
-    decidim (0.23.1)
-      decidim-accountability (= 0.23.1)
-      decidim-admin (= 0.23.1)
-      decidim-api (= 0.23.1)
-      decidim-assemblies (= 0.23.1)
-      decidim-blogs (= 0.23.1)
-      decidim-budgets (= 0.23.1)
-      decidim-comments (= 0.23.1)
-      decidim-core (= 0.23.1)
-      decidim-debates (= 0.23.1)
-      decidim-forms (= 0.23.1)
-      decidim-generators (= 0.23.1)
-      decidim-meetings (= 0.23.1)
-      decidim-pages (= 0.23.1)
-      decidim-participatory_processes (= 0.23.1)
-      decidim-proposals (= 0.23.1)
-      decidim-sortitions (= 0.23.1)
-      decidim-surveys (= 0.23.1)
-      decidim-system (= 0.23.1)
-      decidim-verifications (= 0.23.1)
     declarative-builder (0.1.0)
       declarative-option (< 0.2.0)
     declarative-option (0.1.0)
@@ -488,9 +488,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
-    mimemagic (0.3.10)
-      nokogiri (~> 1)
-      rake
+    mimemagic (0.3.5)
     mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
@@ -777,7 +775,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (~> 1.4)
   byebug (~> 11.0)
-  decidim (>= 0.20.0)
+  decidim (~> 0.23.1)
   decidim-analytics!
   decidim-dev!
   faker (~> 1.9)
@@ -793,4 +791,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   2.2.24
+   2.2.2

--- a/app/controllers/decidim/analytics/admin/analytics_controller.rb
+++ b/app/controllers/decidim/analytics/admin/analytics_controller.rb
@@ -4,8 +4,9 @@ module Decidim
   module Analytics
     module Admin
       class AnalyticsController < Analytics::Admin::ApplicationController
-
         def index
+          enforce_permission_to :read, :analytics
+
           @server_address = Rails.application.secrets.dig(:matomo, :server_address)
           @site_id = Rails.application.secrets.dig(:matomo, :site_id)
           @token_auth = Rails.application.secrets.dig(:matomo, :token_auth)

--- a/app/controllers/decidim/analytics/admin/application_controller.rb
+++ b/app/controllers/decidim/analytics/admin/application_controller.rb
@@ -9,6 +9,9 @@ module Decidim
       # Note that it inherits from `Decidim::Admin::Components::BaseController`, which
       # override its layout and provide all kinds of useful methods.
       class ApplicationController < Decidim::Admin::ApplicationController
+        def permission_class_chain
+          [::Decidim::Analytics::Admin::Permissions] + super
+        end
       end
     end
   end

--- a/app/permissions/decidim/analytics/admin/permissions.rb
+++ b/app/permissions/decidim/analytics/admin/permissions.rb
@@ -1,0 +1,25 @@
+
+
+# frozen_string_literal: true
+
+module Decidim
+  module Analytics
+    module Admin
+      class Permissions < Decidim::DefaultPermissions
+        def permissions
+          return permission_action if permission_action.scope != :admin
+          return permission_action unless user&.admin?
+
+          allow! if read_analytics?
+
+          permission_action
+        end
+
+        def read_analytics?
+          permission_action.subject == :analytics &&
+            permission_action.action == :read
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello

#### Description

Add permissions on analytics admin page.
Now, only logged in administrators can access this route.

Fixes #3 

#### Additional information

For now, not admin users trying to accessing this route are redirected on `/admin` and have a 404 status code. The redirection should be fixed